### PR TITLE
Introduce version 1.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Example usage:
 ```
 module "vpc_staging" {
   source = "JakubBialoskorski/vpc/aws"
-  version = "1.0.2"
+  version = "1.0.3"
 
   environment_name        = "staging"
   vpc_cidr                = "10.0.0.0/24"

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,3 +9,8 @@ output "subnet_staging_public_b" {
 output "vpc_id" {
   value = aws_vpc.vpc.id
 }
+
+# not used by the module, added for extended functionality
+output "vpc_cidr" {
+  value = aws_vpc.vpc_cidr
+}

--- a/variables.tf
+++ b/variables.tf
@@ -7,7 +7,7 @@ variable "environment_name" {
 variable "vpc_cidr" {
   type        = string
   description = "VPC CIDR"
-  default     = ""
+  default     = "10.0.0.0/24"
 }
 
 variable "availability_zone" {
@@ -19,13 +19,13 @@ variable "availability_zone" {
 variable "public_subnet_cidr_az_a" {
   type        = list(string)
   description = "Public subnet CIDR within AZ-a"
-  default     = []
+  default     = ["10.0.0.0/25"]
 }
 
 variable "public_subnet_cidr_az_b" {
   type        = list(string)
   description = "Public subnet CIDR within AZ-b"
-  default     = []
+  default     = ["10.0.0.128/25"]
 }
 
 variable "public_subnet_interfix" {


### PR DESCRIPTION
Add defaults for:
* vpc_cidr
* public_subnet_cidr_az_a
* public_subnet_cidr_az_b

They were not required, but it's easier to deploy module with defaults now.
Also, `outputs.tf` have `vpc_cidr` parameter - again, not required by the module itself, but come in handy in some testing scenarios.