### PR TITLE
[hotfix] Introduce version 1.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Example usage:
 ```
 module "vpc_staging" {
   source = "JakubBialoskorski/vpc/aws"
-  version = "1.0.3"
+  version = "1.0.4"
 
   environment_name        = "staging"
   vpc_cidr                = "10.0.0.0/24"

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,8 +9,3 @@ output "subnet_staging_public_b" {
 output "vpc_id" {
   value = aws_vpc.vpc.id
 }
-
-# not used by the module, added for extended functionality
-output "vpc_cidr" {
-  value = aws_vpc.vpc_cidr
-}


### PR DESCRIPTION
Remove unnecessary `vpc_cidr` parameter from `outputs.tf`, as it was not properly implemented.