### PR TITLE
Introduce version 1.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Example usage:
 ```
 module "vpc_staging" {
   source = "JakubBialoskorski/vpc/aws"
-  version = "1.0.4"
+  version = "1.0.5"
 
   environment_name        = "staging"
   vpc_cidr                = "10.0.0.0/24"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,9 @@
-output "subnet_staging_public_a" {
-  value = tolist("${aws_subnet.public_subnet_az_a.*.id}")
+output "public_subnet_ids_az_a" {
+  value = aws_subnet.public_subnet_az_a[*].id
 }
 
-output "subnet_staging_public_b" {
-  value = tolist("${aws_subnet.public_subnet_az_b.*.id}")
+output "public_subnet_ids_az_b" {
+  value = aws_subnet.public_subnet_az_b[*].id
 }
 
 output "vpc_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,11 @@ variable "availability_zone" {
   type        = list(string)
   description = "Availability Zone"
   default     = ["us-east-1a", "us-east-1b"]
+
+  validation {
+    condition     = length(var.availability_zone) == 2
+    error_message = "availability_zone must contain exactly 2 entries (one per public subnet group)."
+  }
 }
 
 variable "public_subnet_cidr_az_a" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0, < 7.0"
+    }
+  }
+}


### PR DESCRIPTION
* Pin `required_version` and the `aws` provider version constraint (`versions.tf`), so consumers aren't silently exposed to provider major-version changes.
* Fix deprecated string-interpolated splat syntax in `outputs.tf` and rename outputs from `subnet_staging_public_a/b` to `public_subnet_ids_az_a/b`, since the old names hardcoded "staging" despite the module being environment-agnostic.
* Add a `validation` block on `availability_zone` requiring exactly 2 entries, since the module indexes it positionally (`[0]`/`[1]`).
* Update README example to reference 1.0.5.

**⚠️ Breaking change:** consumers referencing the module outputs `subnet_staging_public_a` / `subnet_staging_public_b` will need to update to the new output names `public_subnet_ids_az_a` / `public_subnet_ids_az_b`.