### PR TITLE
Introduce version 1.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,23 @@ VPC module to create separated staging environment with two public subnets, as p
 Originally created for ECS development.
 256 IP adresses are available with this setup.
 
-Example usage:
+## Scope
 
-```
+This module provisions a VPC, an Internet Gateway, and **public-only** subnets spread across exactly **2 availability zones**. It does not create NAT gateways, private subnets, or NACLs. If you need private subnets or outbound-only internet access, this module is not the right fit.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.0 |
+| aws | >= 4.0, < 7.0 |
+
+## Example usage
+
+```hcl
 module "vpc_staging" {
-  source = "JakubBialoskorski/vpc/aws"
-  version = "1.0.5"
+  source  = "JakubBialoskorski/vpc/aws"
+  version = "1.0.6"
 
   environment_name        = "staging"
   vpc_cidr                = "10.0.0.0/24"
@@ -18,7 +29,32 @@ module "vpc_staging" {
   public_subnet_cidr_az_b = ["10.0.0.128/25"]
 
   additional_tags = {
-    YourTag     = "whateverYouWant"
+    YourTag = "whateverYouWant"
   }
 }
 ```
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
+| environment\_name | Set environment name | `string` | `""` | no |
+| vpc\_cidr | VPC CIDR | `string` | `"10.0.0.0/24"` | no |
+| availability\_zone | Availability Zone. Must contain exactly 2 entries (one per public subnet group). | `list(string)` | `["us-east-1a", "us-east-1b"]` | no |
+| public\_subnet\_cidr\_az\_a | Public subnet CIDR within AZ-a | `list(string)` | `["10.0.0.0/25"]` | no |
+| public\_subnet\_cidr\_az\_b | Public subnet CIDR within AZ-b | `list(string)` | `["10.0.0.128/25"]` | no |
+| public\_subnet\_interfix | Give interfix to public subnet name | `string` | `"public"` | no |
+| additional\_tags | Variable for additional tags | `map(string)` | `{}` | no |
+| default\_route | Default Route from and to the Internet | `string` | `"0.0.0.0/0"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| vpc\_id | ID of the created VPC |
+| public\_subnet\_ids\_az\_a | IDs of the public subnets created in AZ-a |
+| public\_subnet\_ids\_az\_b | IDs of the public subnets created in AZ-b |
+
+## Upgrading from <= 1.0.4
+
+As of `1.0.5`, the outputs `subnet_staging_public_a` / `subnet_staging_public_b` were renamed to `public_subnet_ids_az_a` / `public_subnet_ids_az_b`. Update any references before upgrading.

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,11 +1,14 @@
 output "public_subnet_ids_az_a" {
-  value = aws_subnet.public_subnet_az_a[*].id
+  description = "IDs of the public subnets created in AZ-a"
+  value       = aws_subnet.public_subnet_az_a[*].id
 }
 
 output "public_subnet_ids_az_b" {
-  value = aws_subnet.public_subnet_az_b[*].id
+  description = "IDs of the public subnets created in AZ-b"
+  value       = aws_subnet.public_subnet_az_b[*].id
 }
 
 output "vpc_id" {
-  value = aws_vpc.vpc.id
+  description = "ID of the created VPC"
+  value       = aws_vpc.vpc.id
 }


### PR DESCRIPTION
* Document module scope (public-only, 2-AZ) and requirements (terraform/aws provider versions).
* Add Inputs/Outputs tables to README and descriptions to outputs.tf.
* Add an upgrade note for the 1.0.5 output rename.